### PR TITLE
Fetch predictions from API

### DIFF
--- a/app/api/predict/route.ts
+++ b/app/api/predict/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { generateWeatherData, predictEnergyConsumption, type DailyInput } from '@/lib/prediction'
+
+export async function POST(request: NextRequest) {
+  const { inputs } = (await request.json()) as { inputs: DailyInput[] }
+  const weather = generateWeatherData(inputs)
+  const results = predictEnergyConsumption(inputs, weather)
+  return NextResponse.json(results)
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,27 +27,12 @@ import {
   type WeatherData,
   type DailyInput,
   type PredictionResult,
-  generateWeatherData,
-  predictEnergyConsumption,
 } from "@/lib/prediction"
+import { fetchPredictions } from "@/lib/api"
+import { createInitialInputs, applyInputPattern } from "@/lib/input-utils"
 
 export default function EnergyPredictionDashboard() {
-  const [dailyInputs, setDailyInputs] = useState<DailyInput[]>(() => {
-    const inputs = []
-    const today = new Date()
-
-    for (let i = 1; i <= 7; i++) {
-      const date = new Date(today)
-      date.setDate(today.getDate() + i)
-
-      inputs.push({
-        date: date.toISOString().split("T")[0],
-        day: `+${i}일차`,
-        targetGeneration: "",
-      })
-    }
-    return inputs
-  })
+  const [dailyInputs, setDailyInputs] = useState<DailyInput[]>(createInitialInputs)
 
   const [bulkValue, setBulkValue] = useState("")
   const [loading, setLoading] = useState(false)
@@ -56,62 +41,47 @@ export default function EnergyPredictionDashboard() {
 
   // 입력값 업데이트
   const updateDailyInput = (index: number, value: string) => {
-    const newInputs = [...dailyInputs]
-    newInputs[index].targetGeneration = value
-    setDailyInputs(newInputs)
+    setDailyInputs((inputs) =>
+      inputs.map((item, idx) =>
+        idx === index ? { ...item, targetGeneration: value } : item,
+      ),
+    )
   }
 
   // 일괄 적용
   const applyBulkValue = () => {
     if (!bulkValue) return
-    const newInputs = dailyInputs.map((input) => ({
-      ...input,
-      targetGeneration: bulkValue,
-    }))
-    setDailyInputs(newInputs)
+    setDailyInputs((inputs) =>
+      inputs.map((input) => ({ ...input, targetGeneration: bulkValue })),
+    )
   }
 
   // 패턴 적용
   const applyPattern = (pattern: "weekday-weekend" | "increasing" | "decreasing") => {
-    const newInputs = [...dailyInputs]
-    const baseValue = 1000
-
-    newInputs.forEach((input, index) => {
-      const date = new Date(input.date)
-      const dayOfWeek = date.getDay()
-
-      switch (pattern) {
-        case "weekday-weekend":
-          // 평일 1200, 주말 800
-          input.targetGeneration = dayOfWeek === 0 || dayOfWeek === 6 ? "800" : "1200"
-          break
-        case "increasing":
-          // 점진적 증가
-          input.targetGeneration = (baseValue + index * 100).toString()
-          break
-        case "decreasing":
-          // 점진적 감소
-          input.targetGeneration = (baseValue + 600 - index * 100).toString()
-          break
-      }
-    })
-    setDailyInputs(newInputs)
+    setDailyInputs(applyInputPattern(dailyInputs, pattern))
   }
 
   // 값 복사
   const copyValue = (fromIndex: number, toIndex: number) => {
-    const newInputs = [...dailyInputs]
-    newInputs[toIndex].targetGeneration = newInputs[fromIndex].targetGeneration
-    setDailyInputs(newInputs)
+    setDailyInputs((inputs) =>
+      inputs.map((item, idx) =>
+        idx === toIndex
+          ? { ...item, targetGeneration: inputs[fromIndex].targetGeneration }
+          : item,
+      ),
+    )
   }
 
   // 값 조정 (+ / -)
   const adjustValue = (index: number, delta: number) => {
-    const newInputs = [...dailyInputs]
-    const currentValue = Number(newInputs[index].targetGeneration) || 0
-    const newValue = Math.max(0, currentValue + delta)
-    newInputs[index].targetGeneration = newValue.toString()
-    setDailyInputs(newInputs)
+    setDailyInputs((inputs) =>
+      inputs.map((item, idx) => {
+        if (idx !== index) return item
+        const currentValue = Number(item.targetGeneration) || 0
+        const newValue = Math.max(0, currentValue + delta)
+        return { ...item, targetGeneration: newValue.toString() }
+      }),
+    )
   }
 
   const handlePredict = async () => {
@@ -120,15 +90,15 @@ export default function EnergyPredictionDashboard() {
 
     setLoading(true)
 
-    await new Promise((resolve) => setTimeout(resolve, 1500))
-    const weather = generateWeatherData()
-    setWeatherData(weather)
-
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    const results = predictEnergyConsumption(dailyInputs, weather)
-    setPredictions(results)
-
-    setLoading(false)
+    try {
+      const results = await fetchPredictions(dailyInputs)
+      setPredictions(results)
+      setWeatherData(results.map((r) => r.weather))
+    } catch (error) {
+      console.error('Failed to fetch predictions', error)
+    } finally {
+      setLoading(false)
+    }
   }
 
   const isFormValid = dailyInputs.every((input) => input.targetGeneration.trim() !== "")

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -6,17 +6,19 @@ import { cn } from "@/lib/utils"
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
+>(
   // 기본 카드 컨테이너
   ({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-lg border bg-card text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+)
 Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -16,14 +16,16 @@ const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
     VariantProps<typeof labelVariants>
+>(
   // 외부에서 ref 사용을 가능하게 함
   ({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-))
+    <LabelPrimitive.Root
+      ref={ref}
+      className={cn(labelVariants(), className)}
+      {...props}
+    />
+  )
+)
 Label.displayName = LabelPrimitive.Root.displayName
 
 // 라벨 컴포넌트를 외부로 노출

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -12,11 +12,12 @@ const Tabs = TabsPrimitive.Root
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(
   // 탭 목록 컨테이너
   ({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
+    <TabsPrimitive.List
+      ref={ref}
+      className={cn(
       "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
       className
     )}
@@ -28,11 +29,12 @@ TabsList.displayName = TabsPrimitive.List.displayName
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(
   // 각 탭 버튼 역할을 하는 컴포넌트
   ({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
       "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className
     )}
@@ -44,11 +46,12 @@ TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(
   // 선택된 탭의 내용을 표시
   ({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
+    <TabsPrimitive.Content
+      ref={ref}
+      className={cn(
       "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className
     )}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,19 @@
+import { DailyInput, PredictionResult } from './prediction'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || ''
+
+export async function fetchPredictions(inputs: DailyInput[]): Promise<PredictionResult[]> {
+  const response = await fetch(`${API_BASE}/api/predict`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ inputs }),
+  })
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch predictions')
+  }
+
+  return response.json()
+}

--- a/lib/input-utils.ts
+++ b/lib/input-utils.ts
@@ -1,0 +1,49 @@
+// Utility functions to handle daily input generation and manipulation
+
+import { type DailyInput } from './prediction'
+
+/**
+ * Generate initial DailyInput objects for the next given number of days.
+ */
+export function createInitialInputs(days: number = 7): DailyInput[] {
+  const today = new Date()
+  return Array.from({ length: days }, (_, index) => {
+    const date = new Date(today)
+    date.setDate(today.getDate() + index + 1)
+    return {
+      date: date.toISOString().split('T')[0],
+      day: `+${index + 1}일차`,
+      targetGeneration: '',
+    }
+  })
+}
+
+/**
+ * Apply a predefined pattern to daily input target generation values.
+ * Returns a new array with the updated values.
+ */
+export function applyInputPattern(
+  inputs: DailyInput[],
+  pattern: 'weekday-weekend' | 'increasing' | 'decreasing',
+): DailyInput[] {
+  const baseValue = 1000
+  return inputs.map((input, index) => {
+    const date = new Date(input.date)
+    const dayOfWeek = date.getDay()
+    let target = input.targetGeneration
+
+    switch (pattern) {
+      case 'weekday-weekend':
+        target = dayOfWeek === 0 || dayOfWeek === 6 ? '800' : '1200'
+        break
+      case 'increasing':
+        target = String(baseValue + index * 100)
+        break
+      case 'decreasing':
+        target = String(baseValue + 600 - index * 100)
+        break
+    }
+
+    return { ...input, targetGeneration: target }
+  })
+}


### PR DESCRIPTION
## Summary
- create `api/predict` endpoint
- get predictions client-side through new API

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68515768e5d0832084c3f2e450a48d6e