### PR TITLE
Update production target naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Weather based electricity prediction
+# Production-based electricity prediction
 
 *Automatically synced with your [v0.dev](https://v0.dev) deployments*
 
@@ -7,8 +7,13 @@
 
 ## Overview
 
-This repository will stay in sync with your deployed chats on [v0.dev](https://v0.dev).
-Any changes you make to your deployed app will be automatically pushed to this repository from [v0.dev](https://v0.dev).
+This project estimates the electricity usage required to manufacture a target
+number of products over the next seven days. Weather data is used to adjust the
+predictions for the selected region.
+
+This repository will stay in sync with your deployed chats on
+[v0.dev](https://v0.dev). Any changes you make to your deployed app will be
+automatically pushed to this repository from [v0.dev](https://v0.dev).
 
 ## Deployment
 

--- a/app/api/predict/route.ts
+++ b/app/api/predict/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
       w.windSpeed,
       w.humidity,
       w.cloudCover,
-      Number(input.targetGeneration),
+      Number(input.targetProduction),
     ];
   });
 
@@ -62,13 +62,13 @@ export async function POST(request: NextRequest) {
   const results: PredictionResult[] = inputs.map((input, idx) => {
     const w = weather[idx];
     const predicted = Math.round(predictions[idx]);
-    const target = Number(input.targetGeneration);
+    const target = Number(input.targetProduction);
     const efficiency = Math.round((predicted / target) * 100);
 
     return {
       date: input.date,
       day: input.day,
-      targetGeneration: target,
+      targetProduction: target,
       predictedConsumption: predicted,
       weather: w,
       efficiency,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * 전력 예측 대시보드 메인 페이지
+ * 제품 생산 전력 예측 대시보드 메인 페이지
  * 다양한 입력 방법을 제공하고 예측 결과를 시각화합니다.
  */
 
@@ -52,7 +52,7 @@ import { createInitialInputs, applyInputPattern } from "@/lib/input-utils";
 import { WeatherCard } from "@/components/WeatherCard";
 import { SummaryCard } from "@/components/SummaryCard";
 const chartConfig = {
-  targetGeneration: { label: "목표 생산량", color: "hsl(var(--chart-1))" },
+  targetProduction: { label: "목표 생산량", color: "hsl(var(--chart-1))" },
   predictedConsumption: { label: "예측 사용량", color: "hsl(var(--chart-2))" },
   efficiency: { label: "효율성", color: "hsl(var(--chart-3))" },
 };
@@ -84,7 +84,7 @@ export default function EnergyPredictionDashboard() {
   const updateDailyInput = (index: number, value: string) => {
     setDailyInputs((inputs) =>
       inputs.map((item, idx) =>
-        idx === index ? { ...item, targetGeneration: value } : item
+        idx === index ? { ...item, targetProduction: value } : item
       )
     );
   };
@@ -93,7 +93,7 @@ export default function EnergyPredictionDashboard() {
   const applyBulkValue = () => {
     if (!bulkValue) return;
     setDailyInputs((inputs) =>
-      inputs.map((input) => ({ ...input, targetGeneration: bulkValue }))
+      inputs.map((input) => ({ ...input, targetProduction: bulkValue }))
     );
   };
 
@@ -109,7 +109,7 @@ export default function EnergyPredictionDashboard() {
     setDailyInputs((inputs) =>
       inputs.map((item, idx) =>
         idx === toIndex
-          ? { ...item, targetGeneration: inputs[fromIndex].targetGeneration }
+          ? { ...item, targetProduction: inputs[fromIndex].targetProduction }
           : item
       )
     );
@@ -120,16 +120,16 @@ export default function EnergyPredictionDashboard() {
     setDailyInputs((inputs) =>
       inputs.map((item, idx) => {
         if (idx !== index) return item;
-        const currentValue = Number(item.targetGeneration) || 0;
+        const currentValue = Number(item.targetProduction) || 0;
         const newValue = Math.max(0, currentValue + delta);
-        return { ...item, targetGeneration: newValue.toString() };
+        return { ...item, targetProduction: newValue.toString() };
       })
     );
   };
 
   const handlePredict = async () => {
     const hasAllInputs = dailyInputs.every(
-      (input) => input.targetGeneration.trim() !== ""
+      (input) => input.targetProduction.trim() !== ""
     );
     if (!hasAllInputs) return;
 
@@ -148,10 +148,10 @@ export default function EnergyPredictionDashboard() {
   };
 
   const isFormValid = dailyInputs.every(
-    (input) => input.targetGeneration.trim() !== ""
+    (input) => input.targetProduction.trim() !== ""
   );
   const totalTarget = predictions.reduce(
-    (sum, p) => sum + p.targetGeneration,
+    (sum, p) => sum + p.targetProduction,
     0
   );
   const totalPredicted = predictions.reduce(
@@ -165,7 +165,7 @@ export default function EnergyPredictionDashboard() {
       )
     : 0;
   const diff = predictions.reduce(
-    (sum, p) => sum + (p.targetGeneration - p.predictedConsumption),
+    (sum, p) => sum + (p.targetProduction - p.predictedConsumption),
     0
   );
   const bestDay = predictions.reduce<PredictionResult | null>((best, p) => {
@@ -181,10 +181,10 @@ export default function EnergyPredictionDashboard() {
         <div className="text-center space-y-2">
           <h1 className="text-4xl font-bold text-gray-900 flex items-center justify-center gap-2">
             <Zap className="h-8 w-8 text-yellow-500" />
-            7일간 전력 사용량 예측 시스템
+            7일간 제품 생산 전력 예측 시스템
           </h1>
           <p className="text-gray-600">
-            각 날짜별 목표 전력 생산량과 기상 데이터를 기반으로 내일부터 7일간
+            각 날짜별 목표 제품 생산량과 기상 데이터를 기반으로 내일부터 7일간
             전력 사용량을 예측합니다
           </p>
         </div>
@@ -194,7 +194,7 @@ export default function EnergyPredictionDashboard() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Calendar className="h-5 w-5" />
-              7일간 목표 전력 생산량 입력
+              7일간 목표 제품 생산량 입력
             </CardTitle>
             <CardDescription>
               빠르고 쉬운 입력을 위한 다양한 방법을 제공합니다
@@ -251,7 +251,7 @@ export default function EnergyPredictionDashboard() {
                   >
                     <div className="font-medium">평일/주말 패턴</div>
                     <div className="text-sm text-gray-500">
-                      평일 1200kWh, 주말 800kWh
+                      평일 1200개, 주말 800개
                     </div>
                   </Button>
 
@@ -261,7 +261,7 @@ export default function EnergyPredictionDashboard() {
                     className="h-auto p-4 flex flex-col items-start"
                   >
                     <div className="font-medium">점진적 증가</div>
-                    <div className="text-sm text-gray-500">1000 → 1600kWh</div>
+                    <div className="text-sm text-gray-500">1000 → 1600개</div>
                   </Button>
 
                   <Button
@@ -270,7 +270,7 @@ export default function EnergyPredictionDashboard() {
                     className="h-auto p-4 flex flex-col items-start"
                   >
                     <div className="font-medium">점진적 감소</div>
-                    <div className="text-sm text-gray-500">1600 → 1000kWh</div>
+                    <div className="text-sm text-gray-500">1600 → 1000개</div>
                   </Button>
                 </div>
               </TabsContent>
@@ -291,7 +291,7 @@ export default function EnergyPredictionDashboard() {
                           const newInputs = [...dailyInputs];
                           pattern.forEach((value, index) => {
                             if (newInputs[index]) {
-                              newInputs[index].targetGeneration =
+                              newInputs[index].targetProduction =
                                 value.toString();
                             }
                           });
@@ -311,7 +311,7 @@ export default function EnergyPredictionDashboard() {
                           const newInputs = [...dailyInputs];
                           pattern.forEach((value, index) => {
                             if (newInputs[index]) {
-                              newInputs[index].targetGeneration =
+                              newInputs[index].targetProduction =
                                 value.toString();
                             }
                           });
@@ -331,7 +331,7 @@ export default function EnergyPredictionDashboard() {
                         <div key={input.date} className="flex justify-between">
                           <span>{input.day}</span>
                           <span className="font-mono">
-                            {input.targetGeneration || "0"} kWh
+                            {input.targetProduction || "0"}개
                           </span>
                         </div>
                       ))}
@@ -360,7 +360,7 @@ export default function EnergyPredictionDashboard() {
                           id={`day-${index}`}
                           type="number"
                           placeholder="1000"
-                          value={input.targetGeneration}
+                          value={input.targetProduction}
                           onChange={(e) =>
                             updateDailyInput(index, e.target.value)
                           }
@@ -472,8 +472,8 @@ export default function EnergyPredictionDashboard() {
                       <YAxis />
                       <ChartTooltip content={<ChartTooltipContent />} />
                       <Bar
-                        dataKey="targetGeneration"
-                        fill="var(--color-targetGeneration)"
+                        dataKey="targetProduction"
+                        fill="var(--color-targetProduction)"
                         name="목표 생산량"
                       />
                       <Line
@@ -553,7 +553,7 @@ export default function EnergyPredictionDashboard() {
                         </td>
                         <td className="p-3 font-medium">{prediction.day}</td>
                         <td className="p-3 text-blue-600 font-semibold">
-                          {prediction.targetGeneration.toLocaleString()} kWh
+                          {prediction.targetProduction.toLocaleString()}개
                         </td>
                         <td className="p-3 text-green-600 font-semibold">
                           {prediction.predictedConsumption.toLocaleString()} kWh
@@ -600,7 +600,7 @@ export default function EnergyPredictionDashboard() {
               title="총 목표 생산량"
               value={
                 <div className="text-2xl font-bold text-blue-600">
-                  {totalTarget.toLocaleString()} kWh
+                  {totalTarget.toLocaleString()}개
                 </div>
               }
               subtitle="7일 총합"

--- a/lib/input-utils.ts
+++ b/lib/input-utils.ts
@@ -13,7 +13,7 @@ export function createInitialInputs(days: number = 7): DailyInput[] {
     return {
       date: date.toISOString().split('T')[0],
       day: `+${index + 1}일차`,
-      targetGeneration: '',
+      targetProduction: '',
     }
   })
 }
@@ -30,7 +30,7 @@ export function applyInputPattern(
   return inputs.map((input, index) => {
     const date = new Date(input.date)
     const dayOfWeek = date.getDay()
-    let target = input.targetGeneration
+    let target = input.targetProduction
 
     switch (pattern) {
       case 'weekday-weekend':
@@ -44,6 +44,6 @@ export function applyInputPattern(
         break
     }
 
-    return { ...input, targetGeneration: target }
+    return { ...input, targetProduction: target }
   })
 }

--- a/lib/prediction.ts
+++ b/lib/prediction.ts
@@ -9,14 +9,14 @@ import { type WeatherData } from "./weather";
 export interface DailyInput {
   date: string;
   day: string;
-  targetGeneration: string;
+  targetProduction: string;
 }
 
 // 예측 결과 구조
 export interface PredictionResult {
   date: string;
   day: string;
-  targetGeneration: number;
+  targetProduction: number;
   predictedConsumption: number;
   weather: WeatherData;
   efficiency: number;
@@ -85,7 +85,7 @@ export function predictEnergyConsumption(
 ): PredictionResult[] {
   return inputs.map((input, index) => {
     const w = weather[index];
-    const generation = Number(input.targetGeneration);
+    const generation = Number(input.targetProduction);
     let consumption = generation * 0.85;
     consumption = applyTemperatureFactor(consumption, w.temperature);
     consumption = applyHumidityFactor(consumption, w.humidity);
@@ -102,7 +102,7 @@ export function predictEnergyConsumption(
     return {
       date: input.date,
       day: input.day,
-      targetGeneration: generation,
+      targetProduction: generation,
       predictedConsumption,
       weather: w,
       efficiency,


### PR DESCRIPTION
## Summary
- rename all `targetGeneration` fields to `targetProduction`
- update UI text for product-based targets
- tweak README overview

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851b0d84e4c8320b88e05cec1037c9b