### PR TITLE
Improve tie-breaking for best prediction day

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This project estimates the electricity usage required to manufacture a target
 number of products over the next seven days. Weather data is used to adjust the
 predictions for the selected region. Efficiency is expressed as the predicted
 energy consumption per product (kWh per unit), where lower values indicate
-better performance.
+better performance. When multiple days show the same efficiency, the day with
+the lower overall predicted consumption is treated as the best option.
 
 This repository will stay in sync with your deployed chats on
 [v0.dev](https://v0.dev). Any changes you make to your deployed app will be

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -170,9 +170,15 @@ export default function EnergyPredictionDashboard() {
     (sum, p) => sum + (p.targetProduction - p.predictedConsumption),
     0
   );
+  // 최저 효율(제품당 전력 사용량)이 동일한 경우
+  // 예측 전력 소비량이 더 낮은 날을 우선 선택한다
   const bestDay = predictions.reduce<PredictionResult | null>((best, p) => {
     if (!best) return p;
-    return p.efficiency < best.efficiency ? p : best;
+    if (p.efficiency < best.efficiency) return p;
+    if (p.efficiency === best.efficiency) {
+      return p.predictedConsumption < best.predictedConsumption ? p : best;
+    }
+    return best;
   }, null);
   const bestIndex = bestDay ? predictions.indexOf(bestDay) : -1;
 


### PR DESCRIPTION
## Summary
- refine how the best day is chosen in the dashboard
- mention tie-breaking rule in README

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b68b6db8832095ff8b9891e5a1af