### PR TITLE
best_model.joblib 호환성 패치

### DIFF
--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -3,11 +3,25 @@ import json
 import joblib
 from pathlib import Path
 
+# Older versions of scikit-learn do not define _RemainderColsList which may
+# exist in the joblib. Provide a simple fallback to allow unpickling.
+try:
+    from sklearn.compose import _column_transformer as _ct
+    if not hasattr(_ct, "_RemainderColsList"):
+        class _RemainderColsList(list):
+            pass
+
+        _ct._RemainderColsList = _RemainderColsList
+except Exception:
+    # If scikit-learn is unavailable, loading the model will fail later and the
+    # caller can handle the error accordingly.
+    pass
+
 ROOT = Path(__file__).resolve().parent.parent
 MODEL = joblib.load(ROOT / "models" / "best_model.joblib")
 
 
-def main():
+def main() -> None:
     payload = json.load(sys.stdin)
     inputs = payload.get("inputs", [])
     preds = MODEL.predict(inputs)


### PR DESCRIPTION
## Summary
- `scripts/predict.py`에서 `sklearn`의 버전 차이로 발생하는 `_RemainderColsList` 오류를 우회하기 위해 임시 클래스를 정의
- 여전히 `best_model.joblib`을 로드하여 예측 수행

## Testing
- `pnpm lint` *(실패: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853acadd6dc8320af6aabed14940aea