### PR TITLE
best_model.joblib 호환성 패치

### DIFF
--- a/app/api/predict/route.ts
+++ b/app/api/predict/route.ts
@@ -21,18 +21,13 @@ export async function POST(request: NextRequest) {
 
   const weather = await fetchWeatherForecast(start, end, lat, lon);
 
+  // 모델은 생산량, 기온, 습도 세 개의 입력만을 사용한다
   const rows = inputs.map((input, idx) => {
     const w = weather[idx];
     return [
-      input.date,
       Number(input.targetProduction),
       w.temperature,
-      w.temperature,
-      w.windSpeed,
       w.humidity,
-      w.humidity,
-      w.cloudCover,
-      Number(input.targetProduction),
     ];
   });
 

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -2,15 +2,40 @@ import sys
 import json
 import joblib
 from pathlib import Path
+from typing import List
+
+try:
+    import pandas as pd
+except Exception:
+    pd = None
+
+# Older versions of scikit-learn do not define _RemainderColsList which may
+# exist in the joblib. Provide a simple fallback to allow unpickling.
+try:
+    from sklearn.compose import _column_transformer as _ct
+    if not hasattr(_ct, "_RemainderColsList"):
+        class _RemainderColsList(list):
+            pass
+
+        _ct._RemainderColsList = _RemainderColsList
+except Exception:
+    # If scikit-learn is unavailable, loading the model will fail later and the
+    # caller can handle the error accordingly.
+    pass
 
 ROOT = Path(__file__).resolve().parent.parent
 MODEL = joblib.load(ROOT / "models" / "best_model.joblib")
 
 
-def main():
+def main() -> None:
     payload = json.load(sys.stdin)
-    inputs = payload.get("inputs", [])
-    preds = MODEL.predict(inputs)
+    inputs: List[List[float]] = payload.get("inputs", [])
+
+    if pd is not None:
+        df = pd.DataFrame(inputs, columns=["생산량", "기온", "습도"])
+        preds = MODEL.predict(df)
+    else:
+        preds = MODEL.predict(inputs)
     json.dump({"predictions": preds.tolist()}, sys.stdout)
 
 


### PR DESCRIPTION
## Summary
- 모델 입력을 `생산량`, `기온`, `습도` 세 가지 특성만 전달하도록 수정
- `scripts/predict.py`에서 입력을 DataFrame으로 변환해 컬럼 이름을 맞춰 예측

## Testing
- `pnpm lint` *(실패: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853acadd6dc8320af6aabed14940aea